### PR TITLE
add primitive_fixed_point_decimal crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ fastnum = "0.2.10"
 num-bigfloat = { version = "1.7.2", default-features = false }
 rug = "1.27.0"
 rust_decimal = { version = "1.37.2", features = ["macros"] }
+primitive_fixed_point_decimal = "0.7"

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -18,5 +18,6 @@ hyperfine --export-markdown result.md --shell=none \
     "$BIN_PATH $RUNS astro-float-bbp" \
     "$BIN_PATH $RUNS fastnum-bbp" \
     "$BIN_PATH $RUNS decimal-rs-bbp" \
+    "$BIN_PATH $RUNS prim-fpdec-bbp" \
     "python main.py C $RUNS" \
     "python main.py PY $RUNS" \


### PR DESCRIPTION
Although other decimal crates also claim to be fixed-point, they all bind the scale to each decimal *instance*, which changes during operations. They're more like [decimal floating point](https://en.wikipedia.org/wiki/Decimal_floating_point). See the [comparison](https://github.com/WuBingzheng/primitive_fixed_point_decimal/blob/master/COMPARISON.md)for details.

While this [`primitive_fixed_point_decimal`](https://docs.rs/primitive_fixed_point_decimal) crate binds the scale to decimal *type*. The decimal types keep their scale for their whole lifetime instead of changing their scale during operations. It is real fixed-point decimal.

Although fixed-point is not suitable for this kind of mathematical calculations, it is still worth measuring the performance.